### PR TITLE
sub-second precision for prometheus time series

### DIFF
--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -278,7 +278,7 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, len(v.Values))
 
 		for i, k := range v.Values {
-			timeField.Set(i, time.Unix(k.Timestamp.Unix(), 0).UTC())
+			timeField.Set(i, k.Timestamp.UTC())
 			value := float64(k.Value)
 			if !math.IsNaN(value) {
 				valueField.Set(i, &value)
@@ -298,7 +298,7 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 }
 
 func scalarToDataFrames(scalar *model.Scalar, query *PrometheusQuery, frames data.Frames) data.Frames {
-	timeVector := []time.Time{time.Unix(scalar.Timestamp.Unix(), 0).UTC()}
+	timeVector := []time.Time{k.Timestamp.UTC()}
 	values := []float64{float64(scalar.Value)}
 	name := fmt.Sprintf("%g", values[0])
 
@@ -317,7 +317,7 @@ func vectorToDataFrames(vector model.Vector, query *PrometheusQuery, frames data
 	for _, v := range vector {
 		name := formatLegend(v.Metric, query)
 		tags := make(map[string]string, len(v.Metric))
-		timeVector := []time.Time{time.Unix(v.Timestamp.Unix(), 0).UTC()}
+		timeVector := []time.Time{k.Timestamp.UTC()}
 		values := []float64{float64(v.Value)}
 
 		for k, v := range v.Metric {
@@ -346,7 +346,7 @@ func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *Prometheu
 	for _, exemplarData := range response {
 		for _, exemplar := range exemplarData.Exemplars {
 			event := ExemplarEvent{}
-			exemplarTime := time.Unix(exemplar.Timestamp.Unix(), 0).UTC()
+			exemplarTime := exemplar.Timestamp.UTC()
 			event.Time = exemplarTime
 			event.Value = float64(exemplar.Value)
 			event.Labels = make(map[string]string)

--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -298,7 +298,7 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 }
 
 func scalarToDataFrames(scalar *model.Scalar, query *PrometheusQuery, frames data.Frames) data.Frames {
-	timeVector := []time.Time{k.Timestamp.UTC()}
+	timeVector := []time.Time{scalar.Timestamp.UTC()}
 	values := []float64{float64(scalar.Value)}
 	name := fmt.Sprintf("%g", values[0])
 

--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -317,7 +317,7 @@ func vectorToDataFrames(vector model.Vector, query *PrometheusQuery, frames data
 	for _, v := range vector {
 		name := formatLegend(v.Metric, query)
 		tags := make(map[string]string, len(v.Metric))
-		timeVector := []time.Time{k.Timestamp.UTC()}
+		timeVector := []time.Time{v.Timestamp.UTC()}
 		values := []float64{float64(v.Value)}
 
 		for k, v := range v.Metric {


### PR DESCRIPTION
I changed these first to `time.Unix(0, k.Timestamp.UnixNano())` like in the PR on the public repo before noticing that's actually a no-op.